### PR TITLE
fix: attrset plugin declaration normalized

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,19 @@
             lua-version ? "5.1",
             disabled-diagnostics ? [],
           }: let
+            pluginPackages =
+              map (
+                x:
+                  if x ? plugin
+                  then x.plugin
+                  else x
+              )
+              plugins;
             partitions = builtins.partition (plugin:
-              plugin.vimPlugin or false
+              plugin.vimPlugin
+              or false
               || plugin.pname or "" == "nvim-treesitter")
-            plugins;
+            pluginPackages;
             nvim-plugins = partitions.right;
             rocks = partitions.wrong;
             plugin-luadirs = builtins.map (plugin: "${plugin}/lua") nvim-plugins;


### PR DESCRIPTION
This is a proposition for the issue #1. It uses `map` to pick the packages from the potential attrsets in the plugins.